### PR TITLE
Modifies gem to replace deprecated 'ddtrace' with 'datadog'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0]
+- Replaces ddtrace with the updated `datadog` gem
+
 ## [1.0.0]
 - Updates ddtrace to the 1.X line and uses that version's `Datadog::Tracer` syntax
 

--- a/datadog-queue-bus.gemspec
+++ b/datadog-queue-bus.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'ddtrace', '~> 1.0'
+  spec.add_dependency 'datadog', '~> 2.0'
   spec.add_dependency 'queue-bus', '~> 0.6'
 
   spec.add_development_dependency 'bundler', '~> 2.4'

--- a/lib/datadog-queue-bus.rb
+++ b/lib/datadog-queue-bus.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'ddtrace'
+require 'datadog'
 require 'queue-bus'
 require 'datadog_queue_bus/version'
 require 'datadog_queue_bus/middleware'

--- a/lib/datadog_queue_bus/version.rb
+++ b/lib/datadog_queue_bus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DatadogQueueBus
-  VERSION = '1.0.0'
+  VERSION = '2.0.0'
 end


### PR DESCRIPTION
The gem `ddtrace` is now `datadog`. Upgrade accordingly. 

https://github.com/DataDog/dd-trace-rb/blob/release/docs/UpgradeGuide2.md